### PR TITLE
Check difference between recipe and pantry content

### DIFF
--- a/src/com/louisa/butlerpantry/PantryLogic.java
+++ b/src/com/louisa/butlerpantry/PantryLogic.java
@@ -45,6 +45,7 @@ public class PantryLogic {
                     }
                 }
         );
+        Logger.logNow(shoppingList.toString());
         return shoppingList;
     }
 
@@ -61,14 +62,9 @@ public class PantryLogic {
         );
     }
 
-    public static void addRecipeIfPossibleCreateShoppingListIfNot(Pantry toUpdate, Pantry recipe) {
-        if (!checkRecipeAgainstPantry(toUpdate, recipe)) {
-            Pantry shoppingList = createShoppingList(toUpdate, recipe);
+    public static void saveShoppingListAsAFile(Pantry shoppingList) {
             WriteFile.writeShoppingListToCSV(shoppingList.toString(), shoppingList.getName());
-        } else {
-            subtractRecipeFromPantry(toUpdate, recipe);
         }
-    }
 
         public static void addShopping (Pantry toUpdate, Pantry entries){
             entries.getInventory().forEach(

--- a/src/com/louisa/test/AddAmountFromShopping.java
+++ b/src/com/louisa/test/AddAmountFromShopping.java
@@ -1,26 +1,37 @@
 package com.louisa.test;
 import com.louisa.butlerpantry.Ingredient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 public class AddAmountFromShopping {
 
-
     @Test
     public void testAddAmountFromShopping() {
-        Ingredient testIngredient = new Ingredient("Flour", "g", BigDecimal.valueOf(1000.0));
-        testIngredient.addAmountFromShopping(BigDecimal.valueOf(500.0));
-        assertEquals(BigDecimal.valueOf(1500), testIngredient.getAmount());
+        Ingredient testIngredient = new Ingredient("Flour", "g", BigDecimal.valueOf(1000));
+        testIngredient.addAmountFromShopping(BigDecimal.valueOf(500));
+        assertEquals(BigDecimal.valueOf(1500).setScale(2), testIngredient.getAmount());
     }
 
     @Test
     public void testAddNegativeAmount() {
         Ingredient testIngredient = new Ingredient("Flour", "g", BigDecimal.valueOf(50));
         testIngredient.addAmountFromShopping(BigDecimal.valueOf(-0.2));
-        assertEquals(49.8, testIngredient.getAmount());
+        assertEquals(BigDecimal.valueOf(49.8).setScale(2), testIngredient.getAmount());
+    }
+
+    @Test
+    public void testAddAmountFromShoppingWhenAmountIsNegative() {
+        Ingredient testIngredient = new Ingredient("Flour", "g", BigDecimal.valueOf(1000));
+        IllegalArgumentException negativeNumber = Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            testIngredient.addAmountFromShopping(BigDecimal.valueOf(-500));
+        });
     }
 }

--- a/src/com/louisa/test/TestReturnIngredient.java
+++ b/src/com/louisa/test/TestReturnIngredient.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ReturnIngredient {
+public class TestReturnIngredient {
 
     @Test
     public void testReturnIngredientBadStringDouble(){
@@ -14,7 +14,7 @@ public class ReturnIngredient {
         Exception badStringException = assertThrows(Exception.class, () -> {
             Ingredient willNotCome = IngredientLogic.returnIngredient(badString);
         });
-        String expectedMessage = "For input string: \"glory\"";
+        String expectedMessage = "glory";
         String actualMessage = badStringException.getMessage();
 
          assertTrue(actualMessage.contains(expectedMessage));
@@ -27,10 +27,17 @@ public class ReturnIngredient {
         Exception badStringException = assertThrows(Exception.class, () -> {
             Ingredient willNotCome = IngredientLogic.returnIngredient(badString);
         });
-        String expectedMessage = "does it";
+        String expectedMessage = "glory";
         String actualMessage = badStringException.getMessage();
 
         assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void testReturnIngredientNegativeAmount() {
+        IllegalArgumentException badAmountException = assertThrows(IllegalArgumentException.class, () -> {
+            Ingredient willNotCome = IngredientLogic.returnIngredient("Flour,g,-1000");
+        });
     }
 
 }


### PR DESCRIPTION
Adding test case for new, improved Ingredient.addAmountFromShopping() with negative number safety checks.

Adding test case for new, improved IngredientLogic.returnIngredient() with safety check for no negative amounts.

Adding a stdout logger for the difference between recipe and pantry (Logger.logNow()); separating shopping list persistence in its own method (saveShoppingListAsFile) and leaving the flow to main().

